### PR TITLE
Update obsolete parts

### DIFF
--- a/schematics_and_pcbs/imac_g3_333mhz_slot_loading_J20_adapter_board/bill_of_materials.csv
+++ b/schematics_and_pcbs/imac_g3_333mhz_slot_loading_J20_adapter_board/bill_of_materials.csv
@@ -1,5 +1,5 @@
 ﻿"Manufacturer Part Number","Manufacturer","Digi-Key Part Number","Customer Reference","Reference Designator","Packaging","Part Status","Quantity","Unit Price","Extended Price","Quantity Available","Mfg Std Lead Time","Description","RoHS Status","Lead Free Status","REACH Status"
-"9B-16.000MBBK-B","TXC CORPORATION","887-2015-ND","","","Bulk","Active","1","0.30000","$0.30","1681","13 Weeks","CRYSTAL 16.0000MHZ 20PF T/H","RoHS Compliant","Lead free","Not Available"
+"ECS-160-20-4X-DU","ECS Inc.","XC1925-ND","","","","Active","1","","","","","CRYSTAL 16.0000MHZ 20PF T/H","RoHS3 Compliant","Lead free","Not Available"
 "TSW-110-23-G-D","Samtec Inc.","SAM1068-10-ND","","","Bulk","Active","1","1.92000","$1.92","801","Not Available","CONN HEADER VERT 20POS 2.54MM","ROHS3 Compliant","Lead free","REACH Unaffected"
 "L77HDE15SD1CH4F","Amphenol ICC (Commercial Products)","L77HDE15SD1CH4F-ND","","","Tray","Active","1","1.51000","$1.51","147","5 Weeks","CONN DSUB HD RCPT 15POS R/A SLDR","RoHS Compliant","Lead free","Not Available"
 "LCC110","IXYS Integrated Circuits Division","CLA106-ND","","","Tube","Active","1","3.79000","$3.79","1208","6 Weeks","SSR RELAY SPDT 120MA 0-350V","ROHS3 Compliant","Lead free","REACH Unaffected"

--- a/schematics_and_pcbs/imac_g3_slot_loading_J22_adapter_board/bill_of_materials.csv
+++ b/schematics_and_pcbs/imac_g3_slot_loading_J22_adapter_board/bill_of_materials.csv
@@ -5,6 +5,6 @@
 "1935857","Phoenix Contact","277-9080-ND","","","Bulk","Active","1","2.30000","$2.30","605","4 Weeks","TERM BLK 10P SIDE ENTRY 5MM PCB","RoHS Compliant","Lead free","Not Available"
 "67997-206HLF","Amphenol ICC (FCI)","609-3234-ND","","","Bag","Active","1","0.35000","$0.35","10232","13 Weeks","CONN HEADER VERT 6POS 2.54MM","RoHS Compliant","Lead free","REACH Unaffected"
 "CF14JT2K20","Stackpole Electronics Inc","CF14JT2K20CT-ND","","","Cut Tape (CT)","Active","1","0.10000","$0.10","41877","24 Weeks","RES 2.2K OHM 1/4W 5% AXIAL","ROHS3 Compliant","Lead free","REACH Unaffected"
-"USA1H010MDD1TE","Nichicon","493-14556-1-ND","","","Cut Tape (CT)","Active","1","0.29000","$0.29","2916","19 Weeks","CAP ALUM 1UF 20% 50V RADIAL","ROHS3 Compliant","Lead free","REACH Unaffected"
+"ESS105M050AB2EA","KEMET","399-ESS105M050AB2EACT-ND","","","Cut Tape (CT)","Active","1","","","","","CAP ALUM 1UF 20% 50V RADIAL","ROHS3 Compliant","Lead free","REACH Unaffected"
 "AOM-5024L-HD-R","PUI Audio, Inc.","668-1596-ND","","","Bulk","Active","1","3.16000","$3.16","8330","13 Weeks","MICROPHONE COND ANALOG OMNI","ROHS3 Compliant","Lead free","Not Available"
 "929665-02-13-I","3M","3M156308-26-ND","","","Bulk","Active","1","4.95000","$4.95","1523","2 Weeks","CONN HEADER VERT 26POS 2.54MM","RoHS Compliant","Lead free","REACH Unaffected"


### PR DESCRIPTION
Hi, thanks for putting all of this together! I'm looking forward to getting some use out of an iMac that's been collecting dust.

There are a couple of parts in the BOM (crystal and a capacitor) that aren't sold anymore, so here are updated BOMs with current ones. I believe they will work, but I have not actually received the parts yet to test it out.

The new capacitor is not exactly the same (1000 hours instead of 2000 hours) since that wasn't available for any in the right package, but it's got the same specs otherwise. 

When I ordered the board, I also hadn't realized that was an option and modified the footprint on the PCB to accept a 5mm capacitor with 2mm lead spacing, which allowed for an exact match (ESK105M050AC3AA, or 399-6596-ND on digikey). That's not included here because I haven't built or tested the design yet, kicad converted the project to a new version, and I'm not confident that I didn't mess something up. That is in this fork with updated gerbers in case it is of interest to anyone. 